### PR TITLE
Add support for building to test flight

### DIFF
--- a/SDLBird.xcodeproj/project.pbxproj
+++ b/SDLBird.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5291EA8F2C1153DA0022E7EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		52997BFD2C0BB57F00B68BB1 /* SDLBird.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SDLBird.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		52997C0F2C0BB58000B68BB1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52997C122C0BB58000B68BB1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -89,6 +90,7 @@
 		52997BFF2C0BB57F00B68BB1 /* SDLBird */ = {
 			isa = PBXGroup;
 			children = (
+				5291EA8F2C1153DA0022E7EB /* Info.plist */,
 				522626912C0C223A00897A75 /* src */,
 				52997C0F2C0BB58000B68BB1 /* Assets.xcassets */,
 				52997C112C0BB58000B68BB1 /* LaunchScreen.storyboard */,
@@ -338,12 +340,16 @@
 		52997C192C0BB58000B68BB1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLY_RULES_IN_COPY_FILES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = JJ2W5PNDQX;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SDLBird/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = SDLBird;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.arcade-games";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiredDeviceCapabilities = metal;
@@ -354,9 +360,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = tech.hunsaker.SDLBird;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -367,12 +374,16 @@
 		52997C1A2C0BB58000B68BB1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLY_RULES_IN_COPY_FILES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = JJ2W5PNDQX;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SDLBird/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = SDLBird;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.arcade-games";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiredDeviceCapabilities = metal;
@@ -383,9 +394,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = tech.hunsaker.SDLBird;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/SDLBird/Info.plist
+++ b/SDLBird/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Should not need access to this. Deny if it pops up</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Should not need access to this. Deny if it pops up</string>
+</dict>
+</plist>

--- a/SDLBird/src/main.cpp
+++ b/SDLBird/src/main.cpp
@@ -37,6 +37,7 @@ void setup(void) {
     
 }
 
+/// Polls for user input and fires associated events
 void pollInput(void) {
     SDL_Event event;
     SDL_PollEvent(&event);


### PR DESCRIPTION
## Description

Added support for building the app to test flight.

1. Updated the skip build settings for the app and frameworks 
2. Added some privacy descriptions that are required when using SDL

## Test

Created a test flight build